### PR TITLE
change php to 8.3 to allow installation of newer pterodactyl versions & change mariadb repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pteroinstall
 pterodactyl 1.0+ installation script
 
-Made for Ubuntu 20.04 or 22.04 fresh install
+Made for Ubuntu 24.04 fresh install
 Uses 1 FQDN for both panel and Daemon
 
-- 2022 lhridder
+- 2025 Ferox Hosting

--- a/pteroinstall.sh
+++ b/pteroinstall.sh
@@ -154,11 +154,13 @@ echo '
 server_tokens off;
 server {
     listen 80 default_server;
+    listen [::]:80 default_server;
     server_name '"$FQDN"';
     return 301 https://$server_name$request_uri;
 }
 server {
     listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
     server_name '"$FQDN"';
     root /var/www/pterodactyl/public;
     index index.php;

--- a/pteroinstall.sh
+++ b/pteroinstall.sh
@@ -240,19 +240,24 @@ ssl() {
 }
 
 mariadb() {
-  output "###############################################################"
-        output "MARIADB/MySQL INFORMATION"
-        output ""
-        output "Your MariaDB/MySQL root password is $rootpassword"
-        output ""
-        output "Create your MariaDB/MySQL host with the following information:"
-        output "Host: $SERVER_IP"
-        output "Port: 3306"
-        output "User: admin"
-        output "Password: $adminpassword"
-        output "###############################################################"
-        output ""
-  echo "Mysql root password is $rootpassword" > /root/mysqlroot.txt 
+    output "###############################################################"
+    output "MARIADB/MySQL INFORMATION"
+    output ""
+    output "Your MariaDB/MySQL root password is $rootpassword"
+    output ""
+    output "Creating a MariaDB/MySQL host with the following information:"
+    output "Host: $SERVER_IP"
+    output "Port: 3306"
+    output "User: admin"
+    output "Password: $adminpassword"
+    output "###############################################################"
+    output ""
+    echo "Mysql root password is $rootpassword" > /root/mysqlroot.txt 
+
+    # Encrypt the password using Laravel's Crypt facade via artisan tinker
+    encrypted_password=$(php /var/www/pterodactyl/artisan tinker --execute="echo app('encrypter')->encrypt('$adminpassword');" | tr -d '\n')
+    # Insert the row into database_hosts
+    mysql panel -e "INSERT INTO database_hosts (name, host, port, username, password, node_id, created_at, updated_at) VALUES ('main', '$SERVER_IP', 3306, 'admin', '$encrypted_password', 1, NOW(), NOW());"
 }
 
 choices() {

--- a/pteroinstall.sh
+++ b/pteroinstall.sh
@@ -64,12 +64,12 @@ installpanel() {
 	curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
 	echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
 
-	curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash
+	curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash
 	apt update
 
     output "Installing panel dependencies"
 	# install panel dependencies
-	apt -y install php8.1 php8.1-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server fail2ban
+	apt -y install php8.3 php8.3-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server fail2ban
 	# get composer
 	curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
@@ -187,7 +187,7 @@ server {
     }
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/run/php/php8.1-fpm.sock;
+        fastcgi_pass unix:/run/php/php8.3-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";
@@ -250,6 +250,7 @@ mariadb() {
         output "Password: $adminpassword"
         output "###############################################################"
         output ""
+  echo "Mysql root password is $rootpassword" > /root/mysqlroot.txt 
 }
 
 choices() {


### PR DESCRIPTION
Suggesties:

set -e zodat die exit on error


redis leek nog een warning te geven maar dat werkt prima, dus dat is denk ik niks